### PR TITLE
Bugfix/fix required not needed

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,14 +76,14 @@ jobs:
     needs: [unit-tests, check-style]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Download line coverage report
         uses: actions/download-artifact@v3
         with:
           name: coverage
           path: coverage.out
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         env:

--- a/ConfigKey.go
+++ b/ConfigKey.go
@@ -1,0 +1,82 @@
+package verdeter
+
+import (
+	"fmt"
+
+	"github.com/ditrit/verdeter/models"
+	"github.com/spf13/viper"
+)
+
+// Represent a Config Key
+type ConfigKey struct {
+	// the name of the config key
+	Name          string
+	validators    []models.Validator
+	required      bool
+	computedValue models.DefaultValueFunction
+	normalizeFunc models.NormalizationFunction
+}
+
+// Validate the configkey
+//
+// 1. Run the dynamic default function
+// 2. Normalize the value
+// 3. Check the required constraint
+// 4. Check the validators
+func (configKey *ConfigKey) Validate() error {
+	configKey.ComputeDefaultValue()
+	configKey.Normalize()
+
+	err := configKey.CheckRequired()
+	if err != nil {
+		return err
+	}
+
+	err = configKey.CheckValidators()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Normalize the config key using the normalization function if provided
+func (configKey *ConfigKey) Normalize() {
+	if viper.IsSet(configKey.Name) && configKey.normalizeFunc != nil {
+		val := viper.Get(configKey.Name)
+		viper.Set(configKey.Name, configKey.normalizeFunc(val))
+	}
+}
+
+// Compute the default value of the config key using the DefaultValueFunction function if provided
+func (configKey *ConfigKey) ComputeDefaultValue() {
+	if !viper.IsSet(configKey.Name) && configKey.computedValue != nil {
+		viper.Set(configKey.Name, configKey.computedValue())
+	}
+}
+
+// Check if the value is provided if the config key is required
+// Return an error on failure
+func (configKey *ConfigKey) CheckRequired() error {
+	if !viper.IsSet(configKey.Name) && configKey.required {
+		return fmt.Errorf("%q is required", configKey.Name)
+	}
+	return nil
+}
+
+// Return an error on validation failure of one of the validator.
+//
+// Return on first failure, the remaining validator are not ran.
+func (configKey *ConfigKey) CheckValidators() error {
+	for _, validator := range configKey.validators {
+		if !viper.IsSet(configKey.Name) {
+			continue
+		}
+		valKey := viper.Get(configKey.Name)
+		err := validator.Func(valKey)
+		if err != nil {
+			return fmt.Errorf("validation %q failed for key %q (ERROR=%w)", validator.Name, configKey.Name, err)
+		}
+	}
+	return nil
+}

--- a/ConfigKey_test.go
+++ b/ConfigKey_test.go
@@ -1,0 +1,136 @@
+package verdeter
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ditrit/verdeter/models"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigKeyComputedValue(t *testing.T) {
+	viper.Reset()
+	cf := &ConfigKey{
+		Name: "test.ConfigKey",
+		computedValue: func() (dynamicDefault interface{}) {
+			return 2
+		},
+	}
+
+	cf.ComputeDefaultValue()
+	assert.Equal(t, 2, viper.GetInt("test.ConfigKey"))
+	viper.Set("test.ConfigKey", 1)
+	cf.ComputeDefaultValue()
+	assert.Equal(t, 1, viper.GetInt("test.ConfigKey"))
+}
+
+func TestConfigKeyCheckRequired(t *testing.T) {
+	viper.Reset()
+	cf := &ConfigKey{
+		Name:     "test.ConfigKey",
+		required: false,
+	}
+
+	assert.NoError(t, cf.CheckRequired())
+	cf.required = true
+	assert.Error(t, cf.CheckRequired())
+	viper.Set("test.ConfigKey", 1)
+	assert.NoError(t, cf.CheckRequired())
+}
+
+func TestConfigKeyNormalize(t *testing.T) {
+	viper.Reset()
+	cf := &ConfigKey{
+		Name: "test.ConfigKey",
+		normalizeFunc: func(input interface{}) (output interface{}) {
+			intVal := input.(int)
+			return intVal + 1
+		},
+	}
+
+	viper.Set("test.ConfigKey", 1)
+	assert.Equal(t, 1, viper.GetInt("test.ConfigKey"))
+	cf.Normalize()
+	assert.Equal(t, 2, viper.GetInt("test.ConfigKey"))
+}
+
+func TestConfigKeyValidators(t *testing.T) {
+	viper.Reset()
+	cf := &ConfigKey{
+		Name: "test.ConfigKey",
+		validators: []models.Validator{
+			{
+				Name: "greater than 1",
+				Func: func(input interface{}) error {
+					intVal := input.(int)
+					if intVal < 1 {
+						return errors.New("greater than 1")
+					}
+					return nil
+				},
+			}, {
+				Name: "greater than 5",
+				Func: func(input interface{}) error {
+					intVal := input.(int)
+					if intVal < 5 {
+						return errors.New("greater than 5")
+					}
+					return nil
+				},
+			},
+		},
+	}
+
+	viper.Set("test.ConfigKey", 0)
+	assert.Error(t, cf.CheckValidators())
+	viper.Set("test.ConfigKey", 2)
+	assert.Error(t, cf.CheckValidators())
+	viper.Set("test.ConfigKey", 12)
+	assert.NoError(t, cf.CheckValidators())
+}
+
+func TestConfigKeyValidate(t *testing.T) {
+	viper.Reset()
+	cf := &ConfigKey{
+		Name: "test.ConfigKey",
+		validators: []models.Validator{
+			{
+				Name: "greater than 1",
+				Func: func(input interface{}) error {
+					intVal := input.(int)
+					if intVal < 1 {
+						return errors.New("greater than 1")
+					}
+					return nil
+				},
+			}, {
+				Name: "greater than 5",
+				Func: func(input interface{}) error {
+					intVal := input.(int)
+					if intVal < 5 {
+						return errors.New("greater than 5")
+					}
+					return nil
+				},
+			},
+		},
+		required: false,
+		computedValue: func() (dynamicDefault interface{}) {
+			return 50
+		},
+		normalizeFunc: func(input interface{}) (output interface{}) {
+			intVal := input.(int)
+			return intVal + 1
+		},
+	}
+
+	assert.NoError(t, cf.Validate())
+	assert.Equal(t, 51, viper.GetInt("test.ConfigKey"))
+	viper.Set("test.ConfigKey", -1)
+	assert.Error(t, cf.Validate())
+	viper.Set("test.ConfigKey", 1)
+	assert.Error(t, cf.Validate())
+	viper.Set("test.ConfigKey", 11)
+	assert.NoError(t, cf.Validate())
+}

--- a/VerdeterCommand_test.go
+++ b/VerdeterCommand_test.go
@@ -21,3 +21,21 @@ func TestNewVerdeterCommand(t *testing.T) {
 	)
 	assert.NotNil(t, verdeterCmd, "func NewVerdeterCommand should not return something nil")
 }
+
+func TestNewVerdeterCommandLookup(t *testing.T) {
+	verdeterCmd := verdeter.NewVerdeterCommand(
+		"test",
+		"test short description",
+		"test long description",
+		func(verdeterCmd *verdeter.VerdeterCommand, args []string) error {
+			fmt.Println("hello mom")
+			return nil
+		},
+	)
+
+	assert.Nil(t, verdeterCmd.Lookup("some.config"))
+	verdeterCmd.GKey("some.config", verdeter.IsInt, "", "some.config is an simple config key for a unit test")
+	if assert.NotNil(t, verdeterCmd.Lookup("some.config")) {
+		assert.Equal(t, "some.config", verdeterCmd.Lookup("some.config").Name)
+	}
+}

--- a/VerdeterCommandinternal_test.go
+++ b/VerdeterCommandinternal_test.go
@@ -1,0 +1,31 @@
+package verdeter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// This file is intended to hold the tests that need to be run in the verdeter namespace
+
+func TestNewVerdeterCommandAddSubCommand(t *testing.T) {
+	verdeterCmd := NewVerdeterCommand(
+		"test",
+		"test short description",
+		"test long description",
+		func(verdeterCmd *VerdeterCommand, args []string) error {
+			return nil
+		},
+	)
+	assert.Empty(t, verdeterCmd.subCmds)
+	verdeterSubCmd := NewVerdeterCommand(
+		"subtest",
+		"", "",
+		func(verdeterCmd *VerdeterCommand, args []string) error {
+			return nil
+		},
+	)
+	verdeterCmd.AddSubCommand(verdeterSubCmd)
+	assert.NotEmpty(t, verdeterCmd.subCmds)
+
+}

--- a/changelog.md
+++ b/changelog.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A method named `Lookup` on the VerdeterCommand type. It allow to search in both local and global config keys. If no config key is found, it return nil.
+
 ### Changed
 
 - The tasks in the CI are now ran in parallel. 
+- The VerdeterCommand method `SetValidator` is now named `AddValidator`. Although the argument list did not change, the behavior did. Now the method will add a validator to the ConfigKey validators list.
+
+### Fixed 
+
+- fixed a bug regarding the validation cascade in multicommand app. The validation function of a root Command  return an error on valid input when a subcommand was called.
 
 ## [0.2.1] - 2022/10/11
 

--- a/keys.go
+++ b/keys.go
@@ -10,16 +10,18 @@ import (
 )
 
 // LKey defines a local flag for cobra bound to env and config file
-//
-// For an explanation of the difference
 func (verdeterCmd *VerdeterCommand) LKey(name string, valType models.ConfigType, short string, usage string) error {
-	verdeterCmd.keyType[name] = valType
+	verdeterCmd.localConfigKeys[name] = &ConfigKey{
+		Name: name,
+	}
 	return Key(verdeterCmd.cmd, name, valType, short, usage, false)
 }
 
 // GKey defines a global flag for cobra bound to env and config file
 func (verdeterCmd *VerdeterCommand) GKey(name string, valType models.ConfigType, short string, usage string) error {
-	verdeterCmd.keyType[name] = valType
+	verdeterCmd.globalConfigKeys[name] = &ConfigKey{
+		Name: name,
+	}
 	return Key(verdeterCmd.cmd, name, valType, short, usage, true)
 }
 

--- a/run.go
+++ b/run.go
@@ -22,7 +22,7 @@ func preRunCheckE(cfg *VerdeterCommand) func(*cobra.Command, []string) error {
 				return err
 			}
 		}
-		if err := cfg.Validate(); err != nil {
+		if err := cfg.Validate(true); err != nil {
 			return fmt.Errorf("prerun check for %s failed. (Error=%q))", cfg.cmd.Name(), err.Error())
 		} else if len(args) != cfg.nbArgs {
 			return fmt.Errorf("prerun check for %s failed. Expected %v args, got %v", cfg.cmd.Name(), cfg.nbArgs, len(args))

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,4 +6,4 @@ sonar.sources=.
 sonar.exclusions=**/*_test.go,testapp/*
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
-sonar.go.coverage.reportPaths=./coverage.out
+sonar.go.coverage.reportPaths=./coverage.out/coverage.out

--- a/validation.go
+++ b/validation.go
@@ -2,53 +2,33 @@ package verdeter
 
 import (
 	"fmt"
-
-	"github.com/spf13/viper"
 )
 
-// Compute and set default values is not set previously
-// default values comes from the dynamic set of values
-func (verdeterCmd *VerdeterCommand) ComputeDefaultValues() {
-	for key, compute := range verdeterCmd.computedValue {
-		if !viper.IsSet(key) {
-			viper.Set(key, compute())
-		}
-	}
-}
-
-// Normalize config values
-func (verdeterCmd *VerdeterCommand) NormalizeValues() {
-	for key, normalize := range verdeterCmd.normalize {
-		if viper.IsSet(key) {
-			val := viper.Get(key)
-			viper.Set(key, normalize(val))
-		}
-	}
-}
-
 // Validate checks if config keys have valid values
-func (verdeterCmd *VerdeterCommand) Validate() error {
-
+func (verdeterCmd *VerdeterCommand) Validate(isTargetCommand bool) error {
+	// Validate parent command
 	if verdeterCmd.parentCmd != nil {
-		err := verdeterCmd.parentCmd.Validate()
+		err := verdeterCmd.parentCmd.Validate(false)
 		if err != nil {
 			return fmt.Errorf("(from %q) an error happened while verifying parent command %q : %w", verdeterCmd.cmd.Name(), verdeterCmd.parentCmd.cmd.Name(), err)
 		}
 	}
-	verdeterCmd.ComputeDefaultValues()
-	verdeterCmd.NormalizeValues()
 
-	for key := range verdeterCmd.isRequired {
-		if !viper.IsSet(key) {
-			return fmt.Errorf("%q is required", key)
+	// validate global config keys
+	for _, configKey := range verdeterCmd.globalConfigKeys {
+		err := configKey.Validate()
+		if err != nil {
+			return err
 		}
 	}
 
-	for key, validator := range verdeterCmd.isValid {
-		valKey := viper.Get(key)
-		isSet := viper.IsSet(key)
-		if err := validator.Func(valKey); isSet && err != nil {
-			return fmt.Errorf("validation %q failed for key %q (ERROR=%w)", validator.Name, key, err)
+	// validate local config keys
+	if isTargetCommand {
+		for _, configKey := range verdeterCmd.localConfigKeys {
+			err := configKey.Validate()
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/verdeter_test.go
+++ b/verdeter_test.go
@@ -51,9 +51,9 @@ func TestNormalUse(t *testing.T) {
 	cfg.SetConstraint("contraintname", func() bool {
 		return true
 	})
-	cfg.SetRequired("envkey")
 	cfg.LKey("envkey", verdeter.IsStr, "", "test env key")
-	cfg.SetValidator("envkey", validators.StringNotEmpty)
+	cfg.SetRequired("envkey")
+	cfg.AddValidator("envkey", validators.StringNotEmpty)
 
 	cfg.LKey("superkey", verdeter.IsInt, "", "test key in fixture dir")
 	cfg.SetDefault("superkey", -5)
@@ -81,7 +81,7 @@ func TestNormalUse(t *testing.T) {
 	assert.Equal(t, 1234, viper.GetInt("computed"))
 	assert.Equal(t, "envkeyvalue", viper.GetString("envkey"))
 	assert.Equal(t, uint(25), viper.GetUint("myuintkey"))
-	assert.NoError(t, cfg.Validate(), "shouldn't ")
+	assert.NoError(t, cfg.Validate(true), "shouldn't ")
 
 }
 


### PR DESCRIPTION
### Added

- A method named `Lookup` on the VerdeterCommand type. It allow to search in both local and global config keys. If no config key is found, it return nil.

### Changed

- The tasks in the CI are now ran in parallel. 
- The VerdeterCommand method `SetValidator` is now named `AddValidator`. Although the argument list did not change, the behavior did. Now the method will add a validator to the ConfigKey validators list.

### Fixed 

- fixed a bug regarding the validation cascade in multicommand app. The validation function of a root Command  return an error on valid input when a subcommand was called.