### PR TITLE
Bugfix/initialisation not ran

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+### Fixed
+
+- Fixed an initialization bug. The initialization function did not run when a subcommand was called. This caused the command to fail it's validation step. 
+
 ## [0.3.0] - 2022/10/31
 
 ### Added

--- a/run.go
+++ b/run.go
@@ -16,12 +16,11 @@ func RunE(cfg *VerdeterCommand, runf func(cfg *VerdeterCommand, args []string) e
 // Create the a cobra compatible PreRunE function.
 func preRunCheckE(cfg *VerdeterCommand) func(*cobra.Command, []string) error {
 	return func(cobraCmd *cobra.Command, args []string) error {
-		if cfg.parentCmd == nil {
-			err := initConfig(cfg)
-			if err != nil {
-				return err
-			}
+		err := initConfig(cfg)
+		if err != nil {
+			return err
 		}
+
 		if err := cfg.Validate(true); err != nil {
 			return fmt.Errorf("prerun check for %s failed. (Error=%q))", cfg.cmd.Name(), err.Error())
 		} else if len(args) != cfg.nbArgs {


### PR DESCRIPTION
- Fixed an initialization bug. The initialization function did not run when a subcommand was called. This caused the command to fail it's validation step. 
