### PR TITLE
panic on undeclared config key

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `LowerString`, `UpperString` normalizers.
 - Added an URL validator.
 
+### Fixed
+
+- Fixed a bug: the SetDefault method now panic if called on an undeclared config key.
+
 ## [0.3.1] - 2022/11/09
 
 ### Fixed

--- a/verdeter.go
+++ b/verdeter.go
@@ -67,6 +67,10 @@ func (verdeterCmd *VerdeterCommand) SetNormalize(name string, normalize models.N
 
 // SetDefault : set default value for a key
 func (verdeterCmd *VerdeterCommand) SetDefault(name string, value interface{}) {
+	configKey := verdeterCmd.Lookup(name)
+	if configKey == nil {
+		panic(panicMessageLookupFailed(name, "SetDefault"))
+	}
 	viper.SetDefault(name, value)
 }
 

--- a/verdeter_test.go
+++ b/verdeter_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestNormalUse(t *testing.T) {
+	viper.Reset()
 	// set an env key for later
 	os.Setenv("TEST_ENVKEY", "envkeyvalue")
 	cfg := verdeter.NewVerdeterCommand(
@@ -86,6 +87,7 @@ func TestNormalUse(t *testing.T) {
 }
 
 func TestForceConfigFileValid(t *testing.T) {
+	viper.Reset()
 	cfg := verdeter.NewVerdeterCommand(
 		"superuncommonappnamevalid",
 		"a test command",
@@ -103,6 +105,7 @@ func TestForceConfigFileValid(t *testing.T) {
 }
 
 func TestForceConfigFileInvalid(t *testing.T) {
+	viper.Reset()
 	cfg := verdeter.NewVerdeterCommand(
 		"superuncommonappnameinvalid",
 		"a test command",
@@ -118,4 +121,71 @@ func TestForceConfigFileInvalid(t *testing.T) {
 
 	viper.Set("config_path", "./superuncommonappnameforaconfigfile.yml")
 	assert.NotPanics(t, func() { cfg.Execute() })
+}
+
+func TestSetRequiredPanicOnInvalidKey(t *testing.T) {
+	viper.Reset()
+	cfg := verdeter.NewVerdeterCommand(
+		"superuncommonappnameinvalid",
+		"a test command",
+		"whatever",
+		func(cfg *verdeter.VerdeterCommand, args []string) error {
+			fmt.Printf("args=%v", args)
+			return nil
+		},
+	)
+
+	assert.Panics(t,
+		func() { cfg.SetRequired("unknow string") },
+	)
+}
+
+func TestSetDefaultPanicOnInvalidKey(t *testing.T) {
+	viper.Reset()
+	cfg := verdeter.NewVerdeterCommand(
+		"superuncommonappnameinvalid",
+		"a test command",
+		"whatever",
+		func(cfg *verdeter.VerdeterCommand, args []string) error {
+			fmt.Printf("args=%v", args)
+			return nil
+		},
+	)
+
+	assert.Panics(t,
+		func() { cfg.SetDefault("unknow string", 125) },
+	)
+}
+func TestSetNormalizePanicOnInvalidKey(t *testing.T) {
+	viper.Reset()
+	cfg := verdeter.NewVerdeterCommand(
+		"superuncommonappnameinvalid",
+		"a test command",
+		"whatever",
+		func(cfg *verdeter.VerdeterCommand, args []string) error {
+			fmt.Printf("args=%v", args)
+			return nil
+		},
+	)
+
+	assert.Panics(t,
+		func() { cfg.SetNormalize("unknow string", nil) },
+	)
+}
+
+func TestAddValidatorPanicOnInvalidKey(t *testing.T) {
+	viper.Reset()
+	cfg := verdeter.NewVerdeterCommand(
+		"superuncommonappnameinvalid",
+		"a test command",
+		"whatever",
+		func(cfg *verdeter.VerdeterCommand, args []string) error {
+			fmt.Printf("args=%v", args)
+			return nil
+		},
+	)
+
+	assert.Panics(t,
+		func() { cfg.AddValidator("unknow string", validators.StringNotEmpty) },
+	)
 }


### PR DESCRIPTION
This PR make sure that methods that depends on having a config key declared panics if that config does not exist.

Some missing tests were added.

fix #28 